### PR TITLE
fix: fill src attribute from data-src on images

### DIFF
--- a/content_scripts/tranquilize.js
+++ b/content_scripts/tranquilize.js
@@ -585,6 +585,10 @@ function processContentDoc(contentDoc, thisURL, saveOffline) {
     removeAnchorAttributes(contentDoc);
     console.log("Removed Anchor attributes");
 
+    // Process images that are remaining on the tranquilized page
+    processImages(contentDoc.body);
+    console.log("Processed images")
+
     // Create the tranquility UI related elements
     create_ui_elements(contentDoc, supporting_links, thisURL);
     console.log("Created Tranquility UI elements");
@@ -1110,7 +1114,18 @@ function cloneImages(cdoc, collection) {
         img.alt = images[i].alt;
 
         collection[idx] = img;
-        console.log(images[i].src + ": " + images[i].alt);
+        console.log("cloning image: ", img.src + " : " + img.alt);
+    }
+}
+
+function processImages(cdoc) {
+    let images = cdoc.getElementsByTagName('IMG');
+
+    for (let i = 0; i < images.length; i++) {
+        // if there is a missing source, try to get it from data-src attribute
+        if (!images[i].src && images[i].hasAttribute('data-src')) {
+            images[i].src = images[i].getAttribute('data-src')
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #40
To improve support for NoScript users, we need a way to handle image with data-src attributes which is a common way for many websites to do image lazy loading.
This patch loop over all images and fix the src attribute after all processing has been done.
Originally I intended to fix the src attribute on the cloneImages function but found out that some images were ignored for some reasons.
