### PR TITLE
Fix dark mode margin bug

### DIFF
--- a/css/tranquility.css
+++ b/css/tranquility.css
@@ -30,6 +30,7 @@ body.tranquility
   font-family:Univers,Scala,Georgia,Verdana,Times,Helvetica; 
   text-align:justify;
   line-height:140%;  
+   margin:0px;
 }
 
 div.tranquility_masker


### PR DESCRIPTION
When using a dark theme/background, tranquilizing a site leads to a really annoying white margin around the content. Adding margin=0px to the body CSS via Inspect Element fixes this temporarily - making it part of the body CSS should fix this in general.

![2024-05-25_16-12](https://github.com/ushnisha/tranquility-reader-webextensions/assets/45487680/78f2ac6d-bba5-49a2-b115-1eb75e2c5a3b)
